### PR TITLE
Add NFDeployment interface to support the NF Deployment KRM function 

### DIFF
--- a/nf_deployments/v1alpha1/amf_deployment_types.go
+++ b/nf_deployments/v1alpha1/amf_deployment_types.go
@@ -48,6 +48,21 @@ type AMFDeploymentStatus struct {
 	NFDeploymentStatus `json:",inline" yaml:",inline"`
 }
 
+// Implement NFDeployment interface
+
+func (d *AMFDeployment) GetNFDeploymentSpec() *NFDeploymentSpec {
+	return d.Spec.NFDeploymentSpec.DeepCopy()
+}
+func (d *AMFDeployment) GetNFDeploymentStatus() *NFDeploymentStatus {
+	return d.Status.NFDeploymentStatus.DeepCopy()
+}
+func (d *AMFDeployment) SetNFDeploymentSpec(s *NFDeploymentSpec) {
+	s.DeepCopyInto(&d.Spec.NFDeploymentSpec)
+}
+func (d *AMFDeployment) SetNFDeploymentStatus(s *NFDeploymentStatus) {
+	s.DeepCopyInto(&d.Status.NFDeploymentStatus)
+}
+
 // Interface type metadata.
 var (
 	AMFDeploymentKind              = reflect.TypeOf(AMFDeployment{}).Name()

--- a/nf_deployments/v1alpha1/nf_deployment_interfaces.go
+++ b/nf_deployments/v1alpha1/nf_deployment_interfaces.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Nephio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1alpha1
+
+type NFDeployment interface {
+	GetNFDeploymentSpec() *NFDeploymentSpec
+	GetNFDeploymentStatus() *NFDeploymentStatus
+
+	SetNFDeploymentSpec(s *NFDeploymentSpec)
+	SetNFDeploymentStatus(s *NFDeploymentStatus)
+}

--- a/nf_deployments/v1alpha1/nf_deployment_types.go
+++ b/nf_deployments/v1alpha1/nf_deployment_types.go
@@ -184,11 +184,3 @@ const (
 	// At this stage, the deployment is ready to serve requests.
 	Ready NFDeploymentConditionType = "Ready"
 )
-
-type NFDeployment interface {
-	GetNFDeploymentSpec() *NFDeploymentSpec
-	GetNFDeploymentStatus() *NFDeploymentStatus
-
-	SetNFDeploymentSpec(s *NFDeploymentSpec)
-	SetNFDeploymentStatus(s *NFDeploymentStatus)
-}

--- a/nf_deployments/v1alpha1/nf_deployment_types.go
+++ b/nf_deployments/v1alpha1/nf_deployment_types.go
@@ -184,3 +184,11 @@ const (
 	// At this stage, the deployment is ready to serve requests.
 	Ready NFDeploymentConditionType = "Ready"
 )
+
+type NFDeployment interface {
+	GetNFDeploymentSpec() *NFDeploymentSpec
+	GetNFDeploymentStatus() *NFDeploymentStatus
+
+	SetNFDeploymentSpec(s *NFDeploymentSpec)
+	SetNFDeploymentStatus(s *NFDeploymentStatus)
+}

--- a/nf_deployments/v1alpha1/smf_deployment_types.go
+++ b/nf_deployments/v1alpha1/smf_deployment_types.go
@@ -50,6 +50,21 @@ type SMFDeploymentStatus struct {
 	NFDeploymentStatus `json:",inline" yaml:",inline"`
 }
 
+// Implement NFDeployment interface
+
+func (d *SMFDeployment) GetNFDeploymentSpec() *NFDeploymentSpec {
+	return d.Spec.NFDeploymentSpec.DeepCopy()
+}
+func (d *SMFDeployment) GetNFDeploymentStatus() *NFDeploymentStatus {
+	return d.Status.NFDeploymentStatus.DeepCopy()
+}
+func (d *SMFDeployment) SetNFDeploymentSpec(s *NFDeploymentSpec) {
+	s.DeepCopyInto(&d.Spec.NFDeploymentSpec)
+}
+func (d *SMFDeployment) SetNFDeploymentStatus(s *NFDeploymentStatus) {
+	s.DeepCopyInto(&d.Status.NFDeploymentStatus)
+}
+
 // Interface type metadata.
 var (
 	SMFDeploymentKind              = reflect.TypeOf(SMFDeployment{}).Name()

--- a/nf_deployments/v1alpha1/upf_deployment_types.go
+++ b/nf_deployments/v1alpha1/upf_deployment_types.go
@@ -50,6 +50,21 @@ type UPFDeploymentStatus struct {
 	NFDeploymentStatus `json:",inline" yaml:",inline"`
 }
 
+// Implement NFDeployment interface
+
+func (d *UPFDeployment) GetNFDeploymentSpec() *NFDeploymentSpec {
+	return d.Spec.NFDeploymentSpec.DeepCopy()
+}
+func (d *UPFDeployment) GetNFDeploymentStatus() *NFDeploymentStatus {
+	return d.Status.NFDeploymentStatus.DeepCopy()
+}
+func (d *UPFDeployment) SetNFDeploymentSpec(s *NFDeploymentSpec) {
+	s.DeepCopyInto(&d.Spec.NFDeploymentSpec)
+}
+func (d *UPFDeployment) SetNFDeploymentStatus(s *NFDeploymentStatus) {
+	s.DeepCopyInto(&d.Status.NFDeploymentStatus)
+}
+
 // Interface type metadata.
 var (
 	UPFDeploymentKind              = reflect.TypeOf(UPFDeployment{}).Name()


### PR DESCRIPTION
Add an NFDeployment interface, that allows NF vendors (by implementing the interface) to create SMFDeployment-like CRDs to their own NFs and then use @aakashchan's SDK to create an NFDeployment KRM function based on his code in this PR: https://github.com/nephio-project/nephio/pull/137 