### PR TITLE
Fix typos in the name of XxxDeploymentGroupVersionKind variables

### DIFF
--- a/nf_deployments/v1alpha1/amf_deployment_types.go
+++ b/nf_deployments/v1alpha1/amf_deployment_types.go
@@ -65,8 +65,8 @@ func (d *AMFDeployment) SetNFDeploymentStatus(s *NFDeploymentStatus) {
 
 // Interface type metadata.
 var (
-	AMFDeploymentKind              = reflect.TypeOf(AMFDeployment{}).Name()
-	AMFDeploymentGroupKind         = schema.GroupKind{Group: Group, Kind: AMFDeploymentKind}.String()
-	AMFDeploymentKindAPIVersion    = AMFDeploymentKind + "." + GroupVersion.String()
-	AMFDeploymenteGroupVersionKind = GroupVersion.WithKind(AMFDeploymentKind)
+	AMFDeploymentKind             = reflect.TypeOf(AMFDeployment{}).Name()
+	AMFDeploymentGroupKind        = schema.GroupKind{Group: Group, Kind: AMFDeploymentKind}.String()
+	AMFDeploymentKindAPIVersion   = AMFDeploymentKind + "." + GroupVersion.String()
+	AMFDeploymentGroupVersionKind = GroupVersion.WithKind(AMFDeploymentKind)
 )

--- a/nf_deployments/v1alpha1/smf_deployment_types.go
+++ b/nf_deployments/v1alpha1/smf_deployment_types.go
@@ -67,8 +67,8 @@ func (d *SMFDeployment) SetNFDeploymentStatus(s *NFDeploymentStatus) {
 
 // Interface type metadata.
 var (
-	SMFDeploymentKind              = reflect.TypeOf(SMFDeployment{}).Name()
-	SMFDeploymentGroupKind         = schema.GroupKind{Group: Group, Kind: SMFDeploymentKind}.String()
-	SMFDeploymentKindAPIVersion    = SMFDeploymentKind + "." + GroupVersion.String()
-	SMFDeploymenteGroupVersionKind = GroupVersion.WithKind(SMFDeploymentKind)
+	SMFDeploymentKind             = reflect.TypeOf(SMFDeployment{}).Name()
+	SMFDeploymentGroupKind        = schema.GroupKind{Group: Group, Kind: SMFDeploymentKind}.String()
+	SMFDeploymentKindAPIVersion   = SMFDeploymentKind + "." + GroupVersion.String()
+	SMFDeploymentGroupVersionKind = GroupVersion.WithKind(SMFDeploymentKind)
 )

--- a/nf_deployments/v1alpha1/upf_deployment_types.go
+++ b/nf_deployments/v1alpha1/upf_deployment_types.go
@@ -67,8 +67,8 @@ func (d *UPFDeployment) SetNFDeploymentStatus(s *NFDeploymentStatus) {
 
 // Interface type metadata.
 var (
-	UPFDeploymentKind              = reflect.TypeOf(UPFDeployment{}).Name()
-	UPFDeploymentGroupKind         = schema.GroupKind{Group: Group, Kind: UPFDeploymentKind}.String()
-	UPFDeploymentKindAPIVersion    = UPFDeploymentKind + "." + GroupVersion.String()
-	UPFDeploymenteGroupVersionKind = GroupVersion.WithKind(UPFDeploymentKind)
+	UPFDeploymentKind             = reflect.TypeOf(UPFDeployment{}).Name()
+	UPFDeploymentGroupKind        = schema.GroupKind{Group: Group, Kind: UPFDeploymentKind}.String()
+	UPFDeploymentKindAPIVersion   = UPFDeploymentKind + "." + GroupVersion.String()
+	UPFDeploymentGroupVersionKind = GroupVersion.WithKind(UPFDeploymentKind)
 )


### PR DESCRIPTION
rename `XxxDeploymenteGroupVersionKind` to `XxxDeploymentGroupVersionKind`