### PR TITLE
Fix failing "make generate"

### DIFF
--- a/nf_deployments/v1alpha1/nf_deployment_interfaces.go
+++ b/nf_deployments/v1alpha1/nf_deployment_interfaces.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 package v1alpha1
 
+// +kubebuilder:object:generate=false
 type NFDeployment interface {
 	GetNFDeploymentSpec() *NFDeploymentSpec
 	GetNFDeploymentStatus() *NFDeploymentStatus


### PR DESCRIPTION
Fixes the following: Adding the NFDeployment interface  made `make generate` to fail