### PR TITLE
Fix empty

### DIFF
--- a/infra/v1alpha1/workload_cluster_interfaces.go
+++ b/infra/v1alpha1/workload_cluster_interfaces.go
@@ -30,7 +30,7 @@ func (spec *WorkloadClusterSpec) Validate() error {
 	if spec == nil {
 		return fmt.Errorf("spec invalid: %s", errMissingWorkloadClusterSpec)
 	}
-	if spec.ClusterName == "" || spec.ClusterName == "empty" {
+	if spec.ClusterName == "" || spec.ClusterName == "example" {
 		return fmt.Errorf("spec invalid: %s", errMissingClusterName)
 	}
 	if len(spec.CNIs) == 0 {

--- a/nf_requirements/v1alpha1/interface_interfaces.go
+++ b/nf_requirements/v1alpha1/interface_interfaces.go
@@ -142,8 +142,8 @@ func (spec *InterfaceSpec) Validate() error {
 	return nil
 }
 
-func (r *InterfaceStatus) UpsertIPAllocation(newAllocStatus ipamv1alpha1.IPClaimStatus) {
-	if newAllocStatus.Prefix == nil {
+func (r *InterfaceStatus) UpsertIPClaim(newClaimStatus ipamv1alpha1.IPClaimStatus) {
+	if newClaimStatus.Prefix == nil {
 		return
 	}
 	if r.IPClaimStatus == nil {
@@ -151,12 +151,12 @@ func (r *InterfaceStatus) UpsertIPAllocation(newAllocStatus ipamv1alpha1.IPClaim
 	}
 	for _, alloc := range r.IPClaimStatus {
 
-		if alloc.Prefix != nil && *alloc.Prefix == *newAllocStatus.Prefix {
-			alloc = newAllocStatus
+		if alloc.Prefix != nil && *alloc.Prefix == *newClaimStatus.Prefix {
+			alloc = newClaimStatus
 			return
 		}
 	}
-	r.IPClaimStatus = append(r.IPClaimStatus, newAllocStatus)
+	r.IPClaimStatus = append(r.IPClaimStatus, newClaimStatus)
 }
 
 func (r *InterfaceSpec) GetAddressFamilies() []IPFamily {

--- a/nf_requirements/v1alpha1/interface_test.go
+++ b/nf_requirements/v1alpha1/interface_test.go
@@ -293,7 +293,7 @@ func TestUpsertIPAllocation(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			tc.interfaceStatus.UpsertIPAllocation(tc.claimStatus)
+			tc.interfaceStatus.UpsertIPClaim(tc.claimStatus)
 
 			if len(tc.interfaceStatus.IPClaimStatus) != tc.expectedLength {
 				t.Errorf("-want: %d, +got: %d", tc.expectedLength, len(tc.interfaceStatus.IPClaimStatus))


### PR DESCRIPTION
move empty to example as default name for clusters