### PR TITLE
Update O2IMS Provisioning Request CRD based on updates from O-RAN CR

### DIFF
--- a/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
+++ b/config/crd/bases/o2ims.provisioning.oran.org_provisioningrequests.yaml
@@ -2,8 +2,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
   name: provisioningrequests.o2ims.provisioning.oran.org
 spec:
   group: o2ims.provisioning.oran.org
@@ -11,185 +9,125 @@ spec:
     kind: ProvisioningRequest
     listKind: ProvisioningRequestList
     plural: provisioningrequests
-    shortNames:
-    - oranpr
     singular: provisioningrequest
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .status.provisioningStatus.provisioningState
-      name: ProvisionState
-      type: string
-    - jsonPath: .status.provisioningStatus.provisioningDetails
-      name: ProvisionDetails
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: ProvisioningRequest is the Schema for the provisioningrequests
-          API
-        properties:
-          apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
-              Servers should convert recognized schemas to the latest internal value, and
-              may reject unrecognized values.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-            type: string
-          kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
-              Servers may infer this from the endpoint the client submits requests to.
-              Cannot be updated.
-              In CamelCase.
-              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ProvisioningRequestSpec defines the desired state of ProvisioningRequest
-            properties:
-              description:
-                description: Description specifies a brief description of this provisioning
-                  request, providing additional context or details.
-                type: string
-              extensions:
-                description: Extensions holds additional custom key-value pairs that
-                  can be used to extend the cluster's configuration.
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              name:
-                description: Name specifies a human-readable name for this provisioning
-                  request, intended for identification and descriptive purposes.
-                type: string
-              templateName:
-                description: |-
-                  TemplateName defines the base name of the referenced ClusterTemplate.
-                  The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
-                type: string
-              templateParameters:
-                description: TemplateParameters provides the input data that conforms
-                  to the OpenAPI v3 schema defined in the referenced ClusterTemplate's
-                  spec.templateParameterSchema.
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              templateVersion:
-                description: |-
-                  TemplateVersion defines the version of the referenced ClusterTemplate.
-                  The full name of the ClusterTemplate is constructed as <TemplateName.TemplateVersion>.
-                type: string
-            required:
-            - templateName
-            - templateParameters
-            - templateVersion
-            type: object
-          status:
-            description: ProvisioningRequestStatus defines the observed state of ProvisioningRequest
-            properties:
-              conditions:
-                items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              type: string
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                The current apiVersion of this api is v1alpha1
+            kind:
+              type: string
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                The kind value for this api is ProvisioningRequest
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: |
+                    The name of the ProvisioningRequest custom resource instance contains the provisioningItemId.
+                    The provisioningItemId is the unique SMO provided identifier that the SMO will use to
+                    identify all resources provisioned by this provisioning request in interactions
+                    with the O-Cloud.
+            spec:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: |
+                    the name in this spec section is a human readable name intended for descriptive
+                    purposes, this name is not required to be unique and does not identify a provisioning
+                    request or any provisioned resources.
+                description:
+                  type: string
+                  description: |
+                    A description of this provisioning request.
+                templateName:
+                  type: string
+                  description: |
+                    templateName is the name of the template that the SMO wants to use to provision
+                    resources
+                templateVersion:
+                  type: string
+                  description: |
+                    templateVersion is the version of the template that the SMO wants to use to provision
+                    resources. templateName and templateVersion together uniquely identify the template
+                    instance that the SMO wants to use in the provisioning request.
+                templateParameters:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                  description: |
+                    templateParams carries the parameters required to provision resources using this template.
+                    The type is object as actual parameters are defined by the template.
+                    The template parameter schema itself is not defined here as it is template specific.
+                    The themplate parameter schema must be published by the template provider so that FOCOM can
+                    learn about required parameters and validate the same.
+                    The template parameter schema language must be standardized by O-RAN.
+              required:
+                - templateName
+                - templateVersion
+                - templateParameters
+            status:
+              type: object
+              description: ProvisioningRequestStatus defines the observed state of ProvisioningRequest
+              properties:
+                provisionedResources:
+                  description: |
+                    The resources that have been successfully provisioned as part of the provisioning process.
                   properties:
-                    lastTransitionTime:
-                      description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                    oCloudNodeClusterId:
+                      description: |
+                        The identifier of the provisioned oCloud NodeCluster.
+                      type: string
+                    oCloudInfrastructureResourceIds:
+                      description: |
+                        The list of provisioned infrastructure resource ids.
+                      type: array
+                      items:
+                        type: string
+                        description: |
+                          The provisioned infrastructure resource id.
+                  type: object
+                provisioningStatus:
+                  properties:
+                    provisioningUpdateTime:
+                      description: |
+                        The last update time of the provisioning status.
                       format: date-time
                       type: string
-                    message:
-                      description: |-
-                        message is a human readable message indicating details about the transition.
-                        This may be an empty string.
-                      maxLength: 32768
+                    provisioningMessage:
+                      description: |
+                        The details about the current state of the provisioning process.
                       type: string
-                    observedGeneration:
-                      description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
-                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-                        with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
-                        Producers of specific condition types may define expected values and meanings for this field,
-                        and whether the values are considered a guaranteed API.
-                        The value should be a CamelCase string.
-                        This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
+                    provisioningState:
+                      description: The current state of the provisioning process.
                       enum:
-                      - "True"
-                      - "False"
-                      - Unknown
+                        - progressing
+                        - fulfilled
+                        - failed
+                        - deleting
                       type: string
-                    type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
                   type: object
-                type: array
-              extensions:
-                description: |-
-                  Extensions contain extra details about the resources and the configuration used for/by
-                  the ProvisioningRequest.
-                type: object
-              provisioningStatus:
-                properties:
-                  provisionedResources:
-                    description: The resources that have been successfully provisioned
-                      as part of the provisioning process.
-                    properties:
-                      oCloudNodeClusterId:
-                        description: The identifier of the provisioned oCloud Node
-                          Cluster.
-                        type: string
-                    type: object
-                  provisioningDetails:
-                    description: The details about the current state of the provisioning
-                      process.
-                    type: string
-                  provisioningState:
-                    description: The current state of the provisioning process.
-                    enum:
-                    - progressing
-                    - fulfilled
-                    - failed
-                    - deleting
-                    type: string
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                extensions:
+                  description: |-
+                    Extensions contain extra details about the resources and the configuration used for/by
+                    the ProvisioningRequest.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: {}


### PR DESCRIPTION
The main change to the CRD to the status block and conditions fields, this is from the O-RAN.WG6.TS.O-CLOUD-IM.0-R004-v03.00 CR rev 00.03